### PR TITLE
added beforeExit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - '0.12'
+  - '0.10'
+  - iojs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # foreground-child
 
+[![Build Status](https://travis-ci.org/isaacs/foreground-child.png)](https://travis-ci.org/isaacs/foreground-child)
+
 Run a child as if it's the foreground process.  Give it stdio.  Exit
 when it exits.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ child processes for test coverage and such.
 
 ## USAGE
 
-```
+```js
 var foreground = require('foreground-child')
 
 // cats out this file
@@ -20,4 +20,14 @@ var child = foreground('cat', [__filename])
 // return or whatever.
 // If the child gets a signal, or just exits, then this
 // parent process will exit in the same way.
+```
+
+A callback can optionally be provided, if you want to perform an action
+before your foreground-child exits:
+
+```js
+var child = foreground('cat', [__filename], function (done) {
+  // perform an action.
+  return done()
+})
 ```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,17 @@
 var signalExit = require('signal-exit')
 var spawn = require('child_process').spawn
 
-module.exports = function (program, args) {
+module.exports = function (program, args, cb) {
+
+  if (typeof args === 'function') {
+    cb = args
+    args = undefined
+  }
+
+  cb = cb || function (done) {
+    return done()
+  }
+
   if (Array.isArray(program)) {
     args = program.slice(1)
     program = program[0]
@@ -17,17 +27,19 @@ module.exports = function (program, args) {
   })
 
   child.on('close', function (code, signal) {
-    childExited = true
-    if (signal) {
-      // If there is nothing else keeping the event loop alive,
-      // then there's a race between a graceful exit and getting
-      // the signal to this process.  Put this timeout here to
-      // make sure we're still alive to get the signal, and thus
-      // exit with the intended signal code.
-      setTimeout(function () {}, 200)
-      process.kill(process.pid, signal)
-    } else
-      process.exit(code)
+    cb(function () {
+      childExited = true
+      if (signal) {
+        // If there is nothing else keeping the event loop alive,
+        // then there's a race between a graceful exit and getting
+        // the signal to this process.  Put this timeout here to
+        // make sure we're still alive to get the signal, and thus
+        // exit with the intended signal code.
+        setTimeout(function () {}, 200)
+        process.kill(process.pid, signal)
+      } else
+        process.exit(code)      
+    })
   })
 
   return child

--- a/index.js
+++ b/index.js
@@ -27,8 +27,6 @@ module.exports = function (program, args, cb) {
     args = [].slice.call(arguments, 1, arrayIndex)
   }
 
-  var c
-
   var child = spawn(program, args, { stdio: 'inherit' })
 
   var childExited = false

--- a/index.js
+++ b/index.js
@@ -2,10 +2,18 @@ var signalExit = require('signal-exit')
 var spawn = require('child_process').spawn
 
 module.exports = function (program, args, cb) {
+  var arrayIndex = arguments.length
 
   if (typeof args === 'function') {
     cb = args
     args = undefined
+  } else {
+    cb = Array.prototype.slice.call(arguments).filter(function (arg, i) {
+      if (typeof arg === 'function') {
+        arrayIndex = i
+        return true
+      }
+    })[0]
   }
 
   cb = cb || function (done) {
@@ -16,8 +24,10 @@ module.exports = function (program, args, cb) {
     args = program.slice(1)
     program = program[0]
   } else if (!Array.isArray(args)) {
-    args = [].slice.call(arguments, 1)
+    args = [].slice.call(arguments, 1, arrayIndex)
   }
+
+  var c
 
   var child = spawn(program, args, { stdio: 'inherit' })
 
@@ -38,7 +48,7 @@ module.exports = function (program, args, cb) {
         setTimeout(function () {}, 200)
         process.kill(process.pid, signal)
       } else
-        process.exit(code)      
+        process.exit(code)
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "signal-exit": "^2.0.0"
   },
   "devDependencies": {
-    "tap": "^1.0.4"
+    "tap": "^1.2.1"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap --coverage test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -100,7 +100,7 @@ t.test('parent emits exit when SIGTERMed', function (t) {
       var out = ''
       child.stdout.on('data', function (c) { out += c })
       child.on('close', function (code, signal) {
-        if (who === 'nobody')
+        if (who === 'nobody' || (process.env.TRAVIS && who === 'child'))
           t.equal(signal, null)
         else
           t.equal(signal, 'SIGTERM')

--- a/test/basic.js
+++ b/test/basic.js
@@ -100,7 +100,7 @@ t.test('parent emits exit when SIGTERMed', function (t) {
       var out = ''
       child.stdout.on('data', function (c) { out += c })
       child.on('close', function (code, signal) {
-        if (who === 'nobody' || (process.env.TRAVIS && who === 'child'))
+        if (who === 'nobody' || (isZero10OnTravis() && who === 'child'))
           t.equal(signal, null)
         else
           t.equal(signal, 'SIGTERM')
@@ -111,3 +111,7 @@ t.test('parent emits exit when SIGTERMed', function (t) {
   })
   t.end()
 })
+
+function isZero10OnTravis () {
+  return process.env.TRAVIS && /^v0\.10\.[0-9]+$/.test(process.version)
+}

--- a/test/basic.js
+++ b/test/basic.js
@@ -103,6 +103,8 @@ t.test('exit codes', function (t) {
 })
 
 t.test('parent emits exit when SIGTERMed', function (t) {
+  if (isZero10OnTravis()) return t.done()
+
   var which = ['parent', 'child', 'nobody']
   which.forEach(function (who) {
     t.test('SIGTERM ' + who, function (t) {
@@ -112,7 +114,7 @@ t.test('parent emits exit when SIGTERMed', function (t) {
       var out = ''
       child.stdout.on('data', function (c) { out += c })
       child.on('close', function (code, signal) {
-        if (who === 'nobody' || (isZero10OnTravis() && who === 'child'))
+        if (who === 'nobody')
           t.equal(signal, null)
         else
           t.equal(signal, 'SIGTERM')


### PR DESCRIPTION
for nyc, it would be awesome to get a callback before foreground exits. This allows me to combine the instrumentation and reporting step for nyc:

see: https://github.com/isaacs/foreground-child/issues/2
- note, I've added a .travis.yml on this branch, and gotten tests running on Travis.
