### PR TITLE
Set `process.exitCode` based on the child’s exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ module.exports = function (program, args, cb) {
   })
 
   child.on('close', function (code, signal) {
+    // Allow the callback to inspect the child’s exit code and/or modify it.
+    process.exitCode = signal ? 128 + signal : code
+
     cb(function () {
       childExited = true
       if (signal) {
@@ -79,8 +82,10 @@ module.exports = function (program, args, cb) {
         // exit with the intended signal code.
         setTimeout(function () {}, 200)
         process.kill(process.pid, signal)
-      } else
-        process.exit(code)
+      } else {
+        // Equivalent to process.exit() on Node.js >= 0.11.8
+        process.exit(process.exitCode)
+      }
     })
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -28,6 +28,11 @@ if (process.argv[2] === 'parent') {
   // to the foreground-child process; we should test it.
   if (process.argv[4] === 'beforeExitHandler') {
     cb = function (done) {
+      var expectedExitCode = +process.argv[3]
+      if (expectedExitCode !== process.exitCode) {
+        console.log('unexpected exit code', expectedExitCode, process.exitCode);
+      }
+
       console.log('beforeExitHandler')
       return done()
     }


### PR DESCRIPTION
Set `process.exitCode` so that the the before-exit handler can inspect it and make decisions based on it. `process.exitCode` is the default code used for `process.exit()` since Node.js v0.11.8, so it seems reasonable and in line with the intentions of this module to set it accordingly.
