### PR TITLE
Replace cross-spawn-async with cross-spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,38 +1,5 @@
 var signalExit = require('signal-exit')
-var spawn = require('child_process').spawn
-var crossSpawn = require('cross-spawn-async')
-var fs = require('fs')
-var which = require('which')
-
-function needsCrossSpawn (exe) {
-  if (process.platform !== 'win32') {
-    return false
-  }
-
-  try {
-    exe = which.sync(exe)
-  } catch (er) {
-    // failure to find the file?  cmd probably needed.
-    return true
-  }
-
-  if (/\.(com|cmd|bat)$/i.test(exe)) {
-    // need cmd.exe to run command and batch files
-    return true
-  }
-
-  var buffer = new Buffer(150)
-  try {
-    var fd = fs.openSync(exe, 'r')
-    fs.readSync(fd, buffer, 0, 150, 0)
-  } catch (e) {
-    // If it's not an actual file, probably it needs cmd.exe.
-    // also, would be unsafe to test arbitrary memory on next line!
-    return true
-  }
-
-  return /\#\!(.+)/i.test(buffer.toString().trim())
-}
+var spawn = require('cross-spawn')
 
 module.exports = function (program, args, cb) {
   var arrayIndex = arguments.length
@@ -60,8 +27,7 @@ module.exports = function (program, args, cb) {
     args = [].slice.call(arguments, 1, arrayIndex)
   }
 
-  var spawnfn = needsCrossSpawn(program) ? crossSpawn : spawn
-  var child = spawnfn(program, args, { stdio: 'inherit' })
+  var child = spawn(program, args, { stdio: 'inherit' })
 
   var childExited = false
   signalExit(function (code, signal) {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "cross-spawn-async": "^2.1.1",
-    "signal-exit": "^2.0.0",
-    "which": "^1.2.1"
+    "cross-spawn": "^4",
+    "signal-exit": "^2.0.0"
   },
   "devDependencies": {
     "tap": "^5.1.1"

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ var spawn = require('child_process').spawn
 var signalExit = require('signal-exit')
 
 if (process.argv[2] === 'child') {
+  setTimeout(function(){}, 1000);
   console.log('stdout')
   switch (process.argv[3]) {
   case 'SIGTERM':


### PR DESCRIPTION
The logic for checking whether cross-spawn-async needed to be called is
implemented directly in cross-spawn, so also remove our version of the
logic and the corresponding direct dependency on 'which'.

Also includes a small fix to make the tests more reliable, especially when run with coverage.

Replaces #8
