### PR TITLE
Add timeout to fix race condition in tests

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -9,6 +9,7 @@ if (process.argv[2] === 'child') {
   case 'SIGHUP':
   case 'SIGKILL':
     process.kill(process.pid, process.argv[3])
+    setTimeout(function () {}, 100)
     break
 
   case '0':


### PR DESCRIPTION
Add a timeout to the `process.kill(process.pid, ...)` test cases so that the process is always around long enough to receive the signal.

Example failure: https://travis-ci.org/tapjs/foreground-child/jobs/133638718

I couldn’t reproduce these problems locally, and I find it slightly weird that some sort of exit takes place before `process.kill` succeeds, but this does seem to fix the CI failures…
