### PR TITLE
Use fd numbers instead of 'inherit' for Node v0.10 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (program, args, cb) {
     args = [].slice.call(arguments, 1, arrayIndex)
   }
 
-  var spawnOpts = { stdio: ['inherit', 'inherit', 'inherit'] }
+  var spawnOpts = { stdio: [0, 1, 2] }
 
   if (process.send) {
     spawnOpts.stdio.push('ipc')


### PR DESCRIPTION
Use 0, 1, 2 for specifiying child process stdio instead of 'inherit', since Node v0.10 does not support the latter.

Example failure: https://github.com/bcoe/nyc/issues/275

Sorry I broke this, this time I checked v0.10 manually.

/cc @bcoe @isaacs 
