### PR TITLE
feat: require Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
-  - '4'
-  - '5'
+  - '6'
+  - '8'
+  - '10'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Unreleased
+
+* BREAKING CHANGE: Require Node 6
 
 ## v1.5.6
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '5'
-    - nodejs_version: '4'
-    - nodejs_version: '0.12'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+    - nodejs_version: '10'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.5.6",
   "description": "Run a child as if it's the foreground process.  Give it stdio.  Exit when it exits.",
   "main": "index.js",
-  "directories": {
-    "test": "test"
+  "engines": {
+    "node": ">=6.0.0"
   },
   "dependencies": {
     "cross-spawn": "^4",
@@ -28,6 +28,9 @@
     "url": "https://github.com/tapjs/foreground-child/issues"
   },
   "homepage": "https://github.com/tapjs/foreground-child#readme",
+  "directories": {
+    "test": "test"
+  },
   "files": [
     "index.js"
   ]

--- a/test/basic.js
+++ b/test/basic.js
@@ -119,7 +119,7 @@ t.test('exit codes', function (t) {
   t.end()
 })
 
-t.test('parent emits exit when SIGTERMed', { skip: isZero10OnTravis() || winSignals() }, function (t) {
+t.test('parent emits exit when SIGTERMed', { skip: winSignals() }, function (t) {
   var which = ['parent', 'child', 'nobody']
   which.forEach(function (who) {
     t.test('SIGTERM ' + who, function (t) {
@@ -180,11 +180,6 @@ t.test('IPC forwarding', function (t) {
     t.equal(messages[0].data, 'foobar')
   })
 })
-
-function isZero10OnTravis () {
-  return process.env.TRAVIS && /^v0\.10\.[0-9]+$/.test(process.version) ?
-    'skip on 0.10 on Travis' : false
-}
 
 function winSignals () {
   return process.platform === 'win32' ?


### PR DESCRIPTION
## Why

- Align with Node's support policy by targeting oldest LTS.
- Use promise-based APIs out-of-the box (without having to use bluebird)
- Remove workarounds for old Node versions
- Refactor the internals to use ES syntax (scoped variables, spread args, arrow functions, etc.)

Supporting unmaintained Node versions is proving to be an increasing burden as third party libraries drop support for it (`cross-spawn`, `tap`). Using ES5 syntax while ES2015 brought a lot of improvements to the language is also a weight on maintenance. Finally, this is a pretty mild breaking change: there is no intent to break API compat. Since it implies a semver major update, it will be opt-in and only affect users explicitly updating their projects. The primary motivations for this PR is improving coverage tools using V8, a feature only present on modern Node versions anyway.

## What

- Update CI to run against the currently supported Node versions: Node 6, 8 and 10.
- Add `engines.node` field to `package.json` to warn users trying to use the library on an unmaintained Node version.