### PR TITLE
refactor: avoid returns in module body

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -1,38 +1,49 @@
 var fg = require('../index.js')
 var spawn = require('child_process').spawn
 var signalExit = require('signal-exit')
+var t = require('tap')
 
-if (process.argv[2] === 'child') {
+switch (process.argv[2]) {
+  case 'child':
+    childMain()
+    break
+  case 'parent':
+    parentMain()
+    break
+  case undefined:
+    test()
+    break
+}
+
+function childMain() {
   setTimeout(function(){}, 1000);
   console.log('stdout')
   setTimeout(function () {}, 1000)
   switch (process.argv[3]) {
-  case 'SIGTERM':
-  case 'SIGHUP':
-  case 'SIGKILL':
-    process.kill(process.pid, process.argv[3])
-    setTimeout(function () {}, 100)
-    break
+    case 'SIGTERM':
+    case 'SIGHUP':
+    case 'SIGKILL':
+      process.kill(process.pid, process.argv[3])
+      setTimeout(function () {}, 100)
+      break
 
-  case '0':
-  case '1':
-  case '2':
-    process.exit(+process.argv[3])
-    break
+    case '0':
+    case '1':
+    case '2':
+      process.exit(+process.argv[3])
+      break
 
-  case 'ipc':
-    process.on('message', function(m) {
-      console.log('message received')
-      process.send(m)
-      process.exit(0)
-    })
-    break
+    case 'ipc':
+      process.on('message', function(m) {
+        console.log('message received')
+        process.send(m)
+        process.exit(0)
+      })
+      break
   }
-
-  return
 }
 
-if (process.argv[2] === 'parent') {
+function parentMain() {
   var cb = undefined
 
   // we can optionally assign a beforeExit handler
@@ -58,128 +69,126 @@ if (process.argv[2] === 'parent') {
       console.log('parent exit')
     })
     switch (process.argv[4]) {
-    case 'parent':
-      process.kill(process.pid, 'SIGTERM')
-      break
-    case 'child':
-      process.kill(child.pid, 'SIGTERM')
-      break
-    default:
-      process.exit()
-      break
+      case 'parent':
+        process.kill(process.pid, 'SIGTERM')
+        break
+      case 'child':
+        process.kill(child.pid, 'SIGTERM')
+        break
+      default:
+        process.exit()
+        break
     }
   }
-
-  return
 }
 
-var t = require('tap')
-
-t.test('signals', { skip: winSignals() }, function (t) {
-  var signals = [
-    'SIGTERM',
-    'SIGHUP',
-    'SIGKILL'
-  ]
-  signals.forEach(function (sig) {
-    t.test(sig, function (t) {
-      t.plan(3)
-      var prog = process.execPath
-      var args = [__filename, 'parent', sig]
-      var child = spawn(prog, args)
-      var out = ''
-      child.stdout.on('data', function (c) { out += c })
-      child.on('close', function (code, signal) {
-        t.equal(signal, sig)
-        t.equal(code, null)
-        t.equal(out, 'stdout\n')
+function test() {
+  t.test('signals', { skip: winSignals() }, function (t) {
+    var signals = [
+      'SIGTERM',
+      'SIGHUP',
+      'SIGKILL'
+    ]
+    signals.forEach(function (sig) {
+      t.test(sig, function (t) {
+        t.plan(3)
+        var prog = process.execPath
+        var args = [__filename, 'parent', sig]
+        var child = spawn(prog, args)
+        var out = ''
+        child.stdout.on('data', function (c) { out += c })
+        child.on('close', function (code, signal) {
+          t.equal(signal, sig)
+          t.equal(code, null)
+          t.equal(out, 'stdout\n')
+        })
       })
     })
+    t.end()
   })
-  t.end()
-})
 
-t.test('exit codes', function (t) {
-  var codes = [0, 1, 2]
-  codes.forEach(function (c) {
-    t.test(c, function (t) {
-      t.plan(3)
-      var prog = process.execPath
-      var args = [__filename, 'parent', c]
-      var child = spawn(prog, args)
-      var out = ''
-      child.stdout.on('data', function (c) { out += c })
-      child.on('close', function (code, signal) {
-        t.equal(signal, null)
-        t.equal(code, c)
-        t.equal(out, 'stdout\n')
-      })
-    })
-  })
-  t.end()
-})
-
-t.test('parent emits exit when SIGTERMed', { skip: winSignals() }, function (t) {
-  var which = ['parent', 'child', 'nobody']
-  which.forEach(function (who) {
-    t.test('SIGTERM ' + who, function (t) {
-      var prog = process.execPath
-      var args = [__filename, 'parent', 'signalexit', who]
-      var child = spawn(prog, args)
-      var out = ''
-      child.stdout.on('data', function (c) { out += c })
-      child.on('close', function (code, signal) {
-        if (who === 'nobody')
+  t.test('exit codes', function (t) {
+    var codes = [0, 1, 2]
+    codes.forEach(function (c) {
+      t.test(c, function (t) {
+        t.plan(3)
+        var prog = process.execPath
+        var args = [__filename, 'parent', c]
+        var child = spawn(prog, args)
+        var out = ''
+        child.stdout.on('data', function (c) { out += c })
+        child.on('close', function (code, signal) {
           t.equal(signal, null)
-        else
-          t.equal(signal, 'SIGTERM')
-        t.equal(out, 'parent exit\n')
-        t.end()
+          t.equal(code, c)
+          t.equal(out, 'stdout\n')
+        })
       })
     })
+    t.end()
   })
-  t.end()
-})
 
-t.test('beforeExitHandler', function (t) {
-  var codes = [0, 1, 2]
-  codes.forEach(function (c) {
-    t.test(c, function (t) {
-      t.plan(3)
-      var prog = process.execPath
-      var args = [__filename, 'parent', c, 'beforeExitHandler']
-      var child = spawn(prog, args)
-      var out = ''
-      child.stdout.on('data', function (c) { out += c })
-      child.on('close', function (code, signal) {
-        t.equal(signal, null)
-        t.equal(code, c)
-        t.equal(out, 'stdout\nbeforeExitHandler\n')
+  t.test('parent emits exit when SIGTERMed', { skip: winSignals() }, function (t) {
+    var which = ['parent', 'child', 'nobody']
+    which.forEach(function (who) {
+      t.test('SIGTERM ' + who, function (t) {
+        var prog = process.execPath
+        var args = [__filename, 'parent', 'signalexit', who]
+        var child = spawn(prog, args)
+        var out = ''
+        child.stdout.on('data', function (c) { out += c })
+        child.on('close', function (code, signal) {
+          if (who === 'nobody')
+            t.equal(signal, null)
+          else
+            t.equal(signal, 'SIGTERM')
+          t.equal(out, 'parent exit\n')
+          t.end()
+        })
       })
     })
+    t.end()
   })
-  t.end()
-})
 
-t.test('IPC forwarding', function (t) {
-  t.plan(5)
-  var prog = process.execPath
-  var args = [__filename, 'parent', 'ipc']
-  child = spawn(prog, args, { stdio: ['ipc', 'pipe', 'pipe'] })
-  var out = ''
-  var messages = []
-  child.on('message', function (m) { messages.push(m) })
-  child.stdout.on('data', function (c) { out += c })
-
-  child.send({ data: 'foobar' })
-  child.on('close', function (code, signal) {
-    t.equal(signal, null)
-    t.equal(code, 0)
-    t.equal(out, 'stdout\nmessage received\n')
-    t.equal(messages.length, 1)
-    t.equal(messages[0].data, 'foobar')
+  t.test('beforeExitHandler', function (t) {
+    var codes = [0, 1, 2]
+    codes.forEach(function (c) {
+      t.test(c, function (t) {
+        t.plan(3)
+        var prog = process.execPath
+        var args = [__filename, 'parent', c, 'beforeExitHandler']
+        var child = spawn(prog, args)
+        var out = ''
+        child.stdout.on('data', function (c) { out += c })
+        child.on('close', function (code, signal) {
+          t.equal(signal, null)
+          t.equal(code, c)
+          t.equal(out, 'stdout\nbeforeExitHandler\n')
+        })
+      })
+    })
+    t.end()
   })
-})
+
+  t.test('IPC forwarding', function (t) {
+    t.plan(5)
+    var prog = process.execPath
+    var args = [__filename, 'parent', 'ipc']
+    child = spawn(prog, args, { stdio: ['ipc', 'pipe', 'pipe'] })
+    var out = ''
+    var messages = []
+    child.on('message', function (m) { messages.push(m) })
+    child.stdout.on('data', function (c) { out += c })
+
+    child.send({ data: 'foobar' })
+    child.on('close', function (code, signal) {
+      t.equal(signal, null)
+      t.equal(code, 0)
+      t.equal(out, 'stdout\nmessage received\n')
+      t.equal(messages.length, 1)
+      t.equal(messages[0].data, 'foobar')
+    })
+  })
+}
 
 function winSignals () {
   return process.platform === 'win32' ?

--- a/test/immortal-child.js
+++ b/test/immortal-child.js
@@ -1,11 +1,16 @@
 var node = process.execPath
 
-if (process.argv[2] === 'child')
-  child()
-else if (process.argv[2] === 'parent')
-  parent()
-else
-  test()
+switch (process.argv[2]) {
+  case 'child':
+    child()
+    break
+  case 'parent':
+    parent()
+    break
+  case undefined:
+    test()
+    break
+}
 
 function test () {
   var t = require('tap')


### PR DESCRIPTION
# Why

`return` statements in module body are only supported in Node because its module are in fact `FunctionBody` nodes. These kinds of early returns are not supported in ESM. Avoiding them is an easy fix.

# What

Refactor tests to call specific functions based on the role of the process, instead of using early returns in module body.