### PR TITLE
BREAKING CHANGE: require Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
+  - '12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BREAKING CHANGE: Require Node 6
+* BREAKING CHANGE: Require Node 8
 * Internal: Add lock file
 
 ## v1.5.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
+    - nodejs_version: '12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+if (process.platform !== 'win32') {
+  module.exports = {
+    checkCoverage: true,
+    lines: 100,
+    statements: 100,
+    functions: 100,
+    branches: 100
+  };
+} else {
+  module.exports = {};
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run a child as if it's the foreground process.  Give it stdio.  Exit when it exits.",
   "main": "index.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "cross-spawn": "^6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "postversion": "npm run changelog && git add CHANGELOG.md && git commit -m 'update changelog - '${npm_package_version}"
   },
   "tap": {
-    "100": true
+    "100": true,
+    "jobs": 1
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "postversion": "npm run changelog && git add CHANGELOG.md && git commit -m 'update changelog - '${npm_package_version}"
   },
   "tap": {
-    "100": true,
     "jobs": 1
   },
   "repository": {


### PR DESCRIPTION
## Why

Node 6 is no longer supported by the test framework used for this library, meaning that Node 6 can no longer be checked by CI. Also, Node 6 is no longer reached end of life and is no longer maintained. Because of this, the new Node version required should be updated to Node 8.

## What

- Update CI to run against the currently supported Node versions: Node 8, 10 and 12.
- Update `engines.node` in `package.json`.