### PR TITLE
feat: add watchdog process info as cleanup argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## v3.3
+
+- Include `watchdogPid` as a metadata argument to cleanup
+  function
+
 ## v3.2
 
 - Export `watchdog` and `proxySignals` functionality

--- a/test/normalize-fg-args.ts
+++ b/test/normalize-fg-args.ts
@@ -32,7 +32,7 @@ t.plan(cases.length)
 for (const c of cases) {
   t.test(JSON.stringify(c), t => {
     const norm = normalizeFgArgs(c)
-    norm[3](0, null)
+    norm[3](0, null, {})
     t.equal(norm[0], 'cmd')
     if (Array.isArray(c[1])) {
       t.equal(norm[1], c[1])


### PR DESCRIPTION
In regards to #58 -- this PR sends the watchdog process info as a third argument to the `cleanup` function.

All I really need is the watchdog pid but I figured more info is more helpful. You could probably put the other process info in here too but I don't need it.