### PR TITLE
fix-vuln: patch cross-spawn to fix ReDoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.5",
         "signal-exit": "^4.0.1"
       },
       "devDependencies": {
@@ -1684,12 +1684,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2004,9 +2005,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2119,10 +2121,11 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2644,6 +2647,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4483,6 +4487,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4984,10 +4989,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "devDependencies": {
@@ -2005,9 +2005,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "cross-spawn": "^7.0.0",
+    "cross-spawn": "^7.0.5",
     "signal-exit": "^4.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "cross-spawn": "^7.0.5",
+    "cross-spawn": "^7.0.6",
     "signal-exit": "^4.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Hi! Thanks for putting open-source code out there. I appreciate you.

## Context

I analyzed one of my projects on Snyk and noticed a high vulnerability from somewhere down my dependency chain.

`@tsoa/cli@6.5.1 › glob@10.3.10 › foreground-child@3.1.1 › cross-spawn@7.0.3`

It turns out cross-spawn < 7.0.5 is the problem. The fix is as simple as to update to that patch number or above. (Source: https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230)

## What this PR accomplishes

This PR updates the cross-spawn dependency to its lates patch version number: 7.0.5, published two days ago.

## Approach and tests

I've simply ran `npm audit fix` on the project, then `npm test`. Here's the output I saw:

```
> foreground-child@3.3.0 pretest
> npm run prepare


> foreground-child@3.3.0 prepare
> tshy


> foreground-child@3.3.0 test
> tap

 PASS  test/normalize-fg-args.ts 112 OK 4.253s
 PASS  test/immortal-child.ts 1 OK 5.114s
 PASS  test/basic.ts 47 OK 5.820s
 PASS  test/change-exit.ts 45 OK 6.273s

                       
  🌈 TEST COMPLETE 🌈  
                       

Asserts:  205 pass  0 fail  205 of 205 complete
Suites:     4 pass  0 fail      4 of 4 complete

# { total: 205, pass: 205 }
# time=6412.587ms

Warning: Detected unsettled top-level await at file:///home/alexis/Documents/Dev/foreground-child/node_modules/tap/dist/esm/run.mjs:16
await import(String(await resolveImport('@tapjs/run', await resolveImport('tap', pathToFileURL(resolve('x'))).catch(() => import.meta.url))));
^

```

> 📝 The warning also appears on `main`