### PR TITLE
fix(deps): upgrade cross-spawn to v7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.5",
         "signal-exit": "^4.0.1"
       },
       "devDependencies": {
@@ -2004,9 +2004,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://npm.autodesk.com/artifactory/api/npm/autodesk-npm-virtual/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "cross-spawn": "^7.0.0",
+    "cross-spawn": "^7.0.5",
     "signal-exit": "^4.0.1"
   },
   "scripts": {


### PR DESCRIPTION
as part of https://nvd.nist.gov/vuln/detail/CVE-2024-21538 so we enforce using cross-spawn since v7.0.5