### PR TITLE
feat: upgrade cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "cross-spawn": "^7.0.0",
+    "cross-spawn": "^7.0.5",
     "signal-exit": "^4.0.1"
   },
   "scripts": {


### PR DESCRIPTION
#### Fix cross-spawn vulnerability version 
Versions of the package cross-spawn before 7.0.5 are vulnerable to Regular Expression Denial of Service (ReDoS) due to improper input sanitization. An attacker can increase the CPU usage and crash the program by crafting a very large and well crafted string.
https://github.com/advisories/GHSA-3xgq-45jj-v275