### PR TITLE
fix: fallback to exit(128+signum) when self-signal doesn't terminate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   SpawnOptions,
   ChildProcess,
 } from 'node:child_process'
+import { constants } from 'node:os'
 import { onExit } from 'signal-exit'
 import { proxySignals } from './proxy-signals.js'
 import { watchdog } from './watchdog.js'
@@ -212,7 +213,12 @@ export function foregroundChild(
       // make sure we're still alive to get the signal, and thus
       // exit with the intended signal code.
       /* istanbul ignore next */
-      setTimeout(() => {}, 2000)
+      const sigNum = constants.signals[signal]
+      setTimeout(() => {
+        // Fallback: if the signal didn't kill us, exit with the
+        // conventional 128 + signal_number code.
+        process.exit(128 + (sigNum || 0))
+      }, 2000)
       try {
         process.kill(process.pid, signal)
         /* c8 ignore start */

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import { constants } from 'node:os'
 import t from 'tap'
 import { fileURLToPath } from 'url'
 
@@ -14,7 +15,7 @@ const winSignals = () => {
 
 t.jobs = 3
 t.test('signals', { skip: winSignals() }, t => {
-  const signals = ['SIGTERM', 'SIGHUP', 'SIGKILL']
+  const signals = ['SIGTERM', 'SIGHUP', 'SIGKILL', 'SIGABRT']
   t.jobs = signals.length
   for (const sig of signals) {
     t.test(sig, t => {
@@ -25,8 +26,17 @@ t.test('signals', { skip: winSignals() }, t => {
       const out: Buffer[] = []
       child.stdout.on('data', c => out.push(c))
       child.on('close', (code, signal) => {
-        t.equal(signal, sig)
-        t.equal(code, null)
+        // The parent either dies from the signal directly, or falls
+        // back to process.exit(128 + signum) if the self-signal
+        // doesn't terminate the process (e.g. SIGABRT on Linux).
+        const sigNum = constants.signals[sig as NodeJS.Signals]
+        if (signal) {
+          t.equal(signal, sig)
+          t.equal(code, null)
+        } else {
+          t.equal(signal, null)
+          t.equal(code, 128 + sigNum)
+        }
         t.equal(Buffer.concat(out).toString(), 'stdout\n')
       })
     })

--- a/test/fixtures/basic.js
+++ b/test/fixtures/basic.js
@@ -9,6 +9,7 @@ const childMain = () => {
         case 'SIGTERM':
         case 'SIGHUP':
         case 'SIGKILL':
+        case 'SIGABRT':
             process.kill(process.pid, process.argv[3]);
             break;
         case '0':

--- a/test/fixtures/basic.ts
+++ b/test/fixtures/basic.ts
@@ -11,6 +11,7 @@ const childMain = () => {
     case 'SIGTERM':
     case 'SIGHUP':
     case 'SIGKILL':
+    case 'SIGABRT':
       process.kill(process.pid, process.argv[3])
       break
 


### PR DESCRIPTION
Discovered this while debugging CI where `nyc` was used; tests were green on Linux but red on Windows, because on Linux the parent was silently swallowing the signal death and exiting 0, masking the actual failure. Windows doesn't have POSIX signals at all, so it surfaced the problem differently.

The fix is to replace the empty `setTimeout(() => {}, 2000)` "keepalive" with a fallback that calls `process.exit(128 + signum)` after 2 seconds, using the conventional POSIX shell exit code for signal deaths